### PR TITLE
fix: Lato font in CoffeeTimerApp

### DIFF
--- a/lib/screens/coffee_timer_app.dart
+++ b/lib/screens/coffee_timer_app.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart'; // Add this line
 import '../models/brewing_method.dart';
@@ -19,6 +20,7 @@ class CoffeeTimerApp extends StatelessWidget {
         theme: ThemeData(
           primarySwatch: Colors.brown,
           visualDensity: VisualDensity.adaptivePlatformDensity,
+          fontFamily: kIsWeb ? 'Lato' : null,
         ),
         home: HomeScreen(brewingMethods: brewingMethods),
       ),


### PR DESCRIPTION
Hello, Anton! Thank you for your work!

I've noticed that you have 2 ThemeData but only one of them has fontFamily set. That was a reason why I saw default font on my iPhone SE (1st gen).