### PR TITLE
fix: RecipeDetailRoute must be a top level route

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -12,12 +12,10 @@ class AppRouter extends $AppRouter {
         AutoRoute(
           page: RecipeListRoute.page,
           path: '/recipes/:brewingMethodId',
-          children: [
-            AutoRoute(
-              page: RecipeDetailRoute.page,
-              path: ':id',
-            ),
-          ],
+        ),
+        AutoRoute(
+          page: RecipeDetailRoute.page,
+          path: '/recipes/:brewingMethodId/:recipeId'
         ),
         AutoRoute(
           page: AboutRoute.page,

--- a/lib/app_router.gr.dart
+++ b/lib/app_router.gr.dart
@@ -50,14 +50,14 @@ abstract class $AppRouter extends _i6.RootStackRouter {
       final pathParams = routeData.inheritedPathParams;
       final args = routeData.argsAs<RecipeDetailRouteArgs>(
           orElse: () => RecipeDetailRouteArgs(
-                parent: pathParams.getString('parent'),
-                recipeId: pathParams.getString('id'),
+                brewingMethodId: pathParams.getString('brewingMethodId'),
+                recipeId: pathParams.getString('recipeId'),
               ));
       return _i6.AutoRoutePage<dynamic>(
         routeData: routeData,
         child: _i4.RecipeDetailScreen(
           key: args.key,
-          parent: args.parent,
+          brewingMethodId: args.brewingMethodId,
           recipeId: args.recipeId,
         ),
       );
@@ -143,19 +143,19 @@ class RecipeListRouteArgs {
 class RecipeDetailRoute extends _i6.PageRouteInfo<RecipeDetailRouteArgs> {
   RecipeDetailRoute({
     _i7.Key? key,
-    required String parent,
+    required String brewingMethodId,
     required String recipeId,
     List<_i6.PageRouteInfo>? children,
   }) : super(
           RecipeDetailRoute.name,
           args: RecipeDetailRouteArgs(
             key: key,
-            parent: parent,
+            brewingMethodId: brewingMethodId,
             recipeId: recipeId,
           ),
           rawPathParams: {
-            'parent': parent,
-            'id': recipeId,
+            'brewingMethodId': brewingMethodId,
+            'recipeId': recipeId,
           },
           initialChildren: children,
         );
@@ -169,19 +169,19 @@ class RecipeDetailRoute extends _i6.PageRouteInfo<RecipeDetailRouteArgs> {
 class RecipeDetailRouteArgs {
   const RecipeDetailRouteArgs({
     this.key,
-    required this.parent,
+    required this.brewingMethodId,
     required this.recipeId,
   });
 
   final _i7.Key? key;
 
-  final String parent;
+  final String brewingMethodId;
 
   final String recipeId;
 
   @override
   String toString() {
-    return 'RecipeDetailRouteArgs{key: $key, parent: $parent, recipeId: $recipeId}';
+    return 'RecipeDetailRouteArgs{key: $key, brewingMethodId: $brewingMethodId, recipeId: $recipeId}';
   }
 }
 

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -45,8 +45,8 @@ class _HomeScreenState extends State<HomeScreen> {
                       'Most Recently Used Recipe: ${mostRecentRecipe.name}'),
                   onTap: () {
                     context.router.push(RecipeDetailRoute(
-                        parent: mostRecentRecipe.brewingMethodId,
-                        recipeId: mostRecentRecipe.id));
+                      brewingMethodId: mostRecentRecipe.brewingMethodId,
+                      recipeId: mostRecentRecipe.id));
                   },
                 ),
               Expanded(

--- a/lib/screens/recipe_detail_screen.dart
+++ b/lib/screens/recipe_detail_screen.dart
@@ -12,14 +12,13 @@ import 'package:auto_route/auto_route.dart';
 
 @RoutePage()
 class RecipeDetailScreen extends StatefulWidget {
-  final String parent;
+  final String brewingMethodId;
   final String recipeId;
 
   const RecipeDetailScreen(
-      {Key? key,
-      @PathParam('parent') required this.parent,
-      @PathParam('id') required this.recipeId})
-      : super(key: key);
+      {super.key,
+      @PathParam('brewingMethodId') required this.brewingMethodId,
+      @PathParam('recipeId') required this.recipeId});
 
   @override
   State<RecipeDetailScreen> createState() => _RecipeDetailScreenState();
@@ -44,7 +43,8 @@ class _RecipeDetailScreenState extends State<RecipeDetailScreen> {
 
   Future<void> _loadRecipe() async {
     final recipeProvider = Provider.of<RecipeProvider>(context, listen: false);
-    _updatedRecipe = await recipeProvider.getRecipeById(widget.recipeId);
+    await recipeProvider.fetchRecipes(widget.brewingMethodId);
+    _updatedRecipe = recipeProvider.getRecipeById(widget.recipeId);
     originalCoffee = _updatedRecipe!.coffeeAmount;
     originalWater = _updatedRecipe!.waterAmount;
     initialRatio = originalWater! / originalCoffee!;

--- a/lib/screens/recipe_list_screen.dart
+++ b/lib/screens/recipe_list_screen.dart
@@ -126,8 +126,8 @@ class _RecipeListScreenState extends State<RecipeListScreen>
             recipeProvider.updateLastUsed(recipes[index].id);
 
             context.router.push(RecipeDetailRoute(
-                parent: widget.brewingMethodId ?? 'default',
-                recipeId: recipes[index].id));
+              brewingMethodId: recipes[index].brewingMethodId,
+              recipeId: recipes[index].id));
           },
           trailing: FavoriteButton(
             recipeId: recipes[index]


### PR DESCRIPTION
RecipeDetailRoute must be a top level route instead of child of RecipeListRoute to be able to extract the `brewingMethodId` param from the path. Also, `fetchRecipes` must be called before trying to find recipe by id.