### PR TITLE
Update German Translation of Slurry

### DIFF
--- a/assets/data/de/recipes_aeropress.json
+++ b/assets/data/de/recipes_aeropress.json
@@ -260,7 +260,7 @@
       },
       {
         "order": 4,
-        "description": "Die Gülle leicht umrühren.",
+        "description": "Den Brei leicht umrühren.",
         "time": 10
       },
       {

--- a/assets/data/de/recipes_chemex.json
+++ b/assets/data/de/recipes_chemex.json
@@ -198,7 +198,7 @@
         },
         {
           "order": 6,
-          "description": "Äußeren Rand der Gülle sanft und langsam umrühren.",
+          "description": "Äußeren Rand des Breis sanft und langsam umrühren.",
           "time": 10
         },
         {

--- a/assets/data/de/recipes_kalita.json
+++ b/assets/data/de/recipes_kalita.json
@@ -40,7 +40,7 @@
       },
       {
         "order": 7,
-        "description": "Warten, bis die Gülle zur Hälfte abgelaufen ist.",
+        "description": "Warten, bis der Brei zur Hälfte abgelaufen ist.",
         "time": 40
       },
       {

--- a/assets/data/de/recipes_v60.json
+++ b/assets/data/de/recipes_v60.json
@@ -25,7 +25,7 @@
       },
       {
         "order": 3,
-        "description": "Brüher schwenken, um die Gülle zu vereinheitlichen.",
+        "description": "Brüher schwenken, um den Brei zu vereinheitlichen.",
         "time": 10
       },
       {


### PR DESCRIPTION
The German word 'Gülle' is only used for farm slurry. There is actually no 1:1 translation for 'slurry' in the scope of coffee brewing that I know of, so I used 'Brei' instead which is used for food with a consistency between porridge and mash.